### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           google_login_client_id: ${{ secrets.REACT_APP_GOOGLE_LOGIN_CLIENT_ID }}
           facebook_login_app_id: ${{ secrets.REACT_APP_FACEBOOK_LOGIN_APP_ID }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore